### PR TITLE
docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,8 @@ RUN echo 'eval "$(pyenv virtualenv-init -)"' >> ${HOME}/.bashrc
 #
 RUN set -ex && \
 	curl https://pyenv.run | bash && \
-	pyenv install 3.10.5 && \
-	pyenv global 3.10.5 && \
+	pyenv install 3.10 && \
+	pyenv global 3.10 && \
 	pip install --upgrade pip && \
 	# Ansible
 	pip install ansible && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN set -ex && \
 	"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
 	$(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
 	apt-get update && \
-	apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+	apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-compose
 # pyenv requires
 RUN set -ex && \
 	apt-get update && \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ docker-compose run ubuntu-env
 * docker-ce and docker-compose
 * docker-in-docker
 * pyenv, pipenv, Ansible latest
-* python 3.10.5 or later
+* python 3.10.latest or later
 * pre-commit latest
 * syft, grype latest
 * ohmybash latest


### PR DESCRIPTION
```
Seungs-MacBook-Pro:ubuntu-dev seungyeop$ docker-compose build
[+] Building 328.6s (19/19) FINISHED                                                            
 => [internal] load build definition from Dockerfile                                       0.0s
 => => transferring dockerfile: 3.00kB                                                     0.0s
 => [internal] load .dockerignore                                                          0.0s
 => => transferring context: 2B                                                            0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                            6.7s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                              0.0s
 => [ 1/14] FROM docker.io/library/ubuntu:22.04@sha256:9a0bdde4188b896a372804be2384015e90  0.0s
 => CACHED [ 2/14] RUN groupadd --gid 1000 ubuntu &&  useradd -s /bin/bash --uid 1000 --g  0.0s
eyTypes +ssh-rsa' | sudo tee -a /etc  0.6s 
 => [13/14] RUN set -ex &&  cd /home/ubuntu &&  bash -c "$(curl -fsSL https://raw.githubu  2.3s 
 => [14/14] WORKDIR /ubuntu-env                                                            0.0s 
 => exporting to image                                                                     8.1s 
 => => exporting layers                                                                    8.1s 
 => => writing image sha256:0dbf8d203f9e58f649171fe9f8d9b88ff1445d89f9f26a91a00fbd7c2ffac  0.0s 
 => => naming to ghcr.io/ibm-xaas/ubuntu-env:main                                          0.0s 
                                                                                                
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
Seungs-MacBook-Pro:ubuntu-dev seungyeop$ docker-compose run ubuntu-env
05:27:06 ubuntu@44398bf49500 ubuntu-env ±|docker-compose ✗|→ whereis docker-compose
docker-compose: /usr/bin/docker-compose
05:27:11 ubuntu@44398bf49500 ubuntu-env ±|docker-compose ✗|→ docker-compose build
Building ubuntu-env
[+] Building 0.9s (18/18) FINISHED                                                              
 => [internal] load build definition from Dockerfile                                       0.0s
 => => transferring dockerfile: 3.00kB                                                     0.0s
 => [internal] load .dockerignore                                                          0.0s
 => => transferring context: 2B                                                            0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                            0.7s
 => [ 1/14] FROM docker.io/library/ubuntu:22.04@sha256:9a0bdde4188b896a372804be2384015e90  0.0s
 => CACHED [ 2/14] RUN groupadd --gid 1000 ubuntu &&  useradd -s /bin/bash --uid 1000 --g  0.0s
 
 => CACHED [11/14] RUN set -ex &&  curl -sSfL https://raw.githubusercontent.com/anchore/s  0.0s
 => CACHED [12/14] RUN set -ex &&  echo '    PubkeyAcceptedKeyTypes +ssh-rsa' | sudo tee   0.0s
 => CACHED [13/14] RUN set -ex &&  cd /home/ubuntu &&  bash -c "$(curl -fsSL https://raw.  0.0s
 => CACHED [14/14] WORKDIR /ubuntu-env                                                     0.0s
 => exporting to image                                                                     0.0s
 => => exporting layers                                                                    0.0s
 => => writing image sha256:e4a72acf98dec7d271f084022c8f1f1bd0c6ee65c93e20229e055dff73a3c  0.0s
 => => naming to ghcr.io/ibm-xaas/ubuntu-env:main                                          0.0s
05:27:18 ubuntu@44398bf49500 ubuntu-env ±|docker-compose ✗|→ git add *
05:27:28 ubuntu@44398bf49500 ubuntu-env ±|docker-compose ✗|→ git commit -m "docker-compose"
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/ibm/detect-secrets.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/ibm/detect-secrets.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check for added large files..............................................Passed
Detect secrets...........................................................Passed
[docker-compose f16ed9c] docker-compose
 1 file changed, 1 insertion(+), 1 deletion(-)
05:27:54 ubuntu@44398bf49500 ubuntu-env ±|docker-compose|→ git push
fatal: The current branch docker-compose has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin docker-compose

05:27:57 ubuntu@44398bf49500 ubuntu-env ±|docker-compose|→ git push --set-upstream origin docker-compose
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
Enumerating objects: 5, done.
Counting objects: 100% (5/5), done.
Delta compression using up to 8 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 312 bytes | 62.00 KiB/s, done.
Total 3 (delta 2), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
remote: This repository moved. Please use the new location:
remote:   git@github.com:ibm-xaas/ubuntu-dev.git
remote: 
remote: Create a pull request for 'docker-compose' on GitHub by visiting:
remote:      https://github.com/ibm-xaas/ubuntu-dev/pull/new/docker-compose
remote: 
To github.com:syyang-in-cloud/ubuntu-dev.git
 * [new branch]      docker-compose -> docker-compose
Branch 'docker-compose' set up to track remote branch 'docker-compose' from 'origin'.
05:28:07 ubuntu@44398bf49500 ubuntu-env ±|docker-compose|→ 
```